### PR TITLE
Do not return on filter fail

### DIFF
--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -74,7 +74,7 @@ func (m *Manager) DispatchCloudEvent(event *cloudevents.Event) {
 		res := subscriptionsapi.NewAllFilter(materializeFiltersList(m.ctx, m.triggers[i].Filters)...).Filter(m.ctx, *event)
 		if res == eventfilter.FailFilter {
 			m.logger.Debug("Skipped delivery due to filter", zap.Any("event", *event))
-			return
+			continue
 		}
 
 		for j := range m.triggers[i].Targets {


### PR DESCRIPTION
When a filter fails it should continue to next filter instead of exiting the dispatch routine.