### PR TITLE
Add config poller for brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ kubernetes-namespace      | KUBERNETES_NAMESPACE            | | Namespace where 
 kubernetes-broker-config-secret-name  | KUBERNETES_BROKER_CONFIG_SECRET_NAME | | Secret object name that contains the broker configuration.
 kubernetes-broker-config-secret-key   | KUBERNETES_BROKER_CONFIG_SECRET_KEY  | | Secret object key that contains the broker configuration.
 kubernetes-observability-config-map-name  | KUBERNETES_OBSERVABILITY_CONFIGMAP_NAME || ConfigMap object name that contains the observability configuration.
-observability-metrics-domain          | OBSERVABILITY_METRICS_DOMAIN      | Domain to be used for some metrics reporters.
+config-polling-period                 | CONFIG_POLLING_PERIOD    | PT0S | ISO8601 duration for config polling. Disabled if PT0S. Enabling it will disable the file watcher.
+observability-metrics-domain          | OBSERVABILITY_METRICS_DOMAIN  | triggermesh.io/eventing | Domain to be used for some metrics reporters.
 redis.address             | REDIS_ADDRESS                   | 0.0.0.0:6379 | Redis address.
 redis.username            | REDIS_USERNAME                  | | Redis username.
 redis.password            | REDIS_PASSWORD                  | | Redis password.

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/triggermesh/brokers/pkg/broker/cmd"
 	"github.com/triggermesh/brokers/pkg/common/fs"
 	"github.com/triggermesh/brokers/pkg/common/kubernetes/controller"
+	cfgbpoller "github.com/triggermesh/brokers/pkg/config/broker/poller"
 	cfgbwatcher "github.com/triggermesh/brokers/pkg/config/broker/watcher"
 	cfgowatcher "github.com/triggermesh/brokers/pkg/config/observability/watcher"
 	"github.com/triggermesh/brokers/pkg/ingest"
@@ -40,8 +41,10 @@ type Instance struct {
 	subscription *subscriptions.Manager
 	bcw          *cfgbwatcher.Watcher
 	ocw          *cfgowatcher.Watcher
-	km           *controller.Manager
-	status       Status
+	bcp          *cfgbpoller.Poller
+	// ocp          *cfgopoller.Poller
+	km     *controller.Manager
+	status Status
 
 	logger *zap.SugaredLogger
 }
@@ -90,17 +93,17 @@ func NewInstance(globals *cmd.Globals, b backend.Interface) (*Instance, error) {
 			return nil, fmt.Errorf("error resolving to absolute path %q: %w", globals.BrokerConfigPath, err)
 		}
 
-		if globals.NeedsBrokerConfigFileWatcher() {
+		if globals.NeedsBrokerConfigFromFile() {
 			globals.Logger.Debugw("Creating watcher for broker configuration", zap.String("file", configPath))
 			bcfgw, err := cfgbwatcher.NewWatcher(cfw, configPath, globals.Logger.Named("cgfwatch"))
 			if err != nil {
-				return nil, fmt.Errorf("error adding broker watcher for %q: %w", globals.ObservabilityConfigPath, err)
+				return nil, fmt.Errorf("error adding broker watcher for %q: %w", configPath, err)
 			}
 
 			broker.bcw = bcfgw
 		}
 
-		if globals.NeedsObservabilityConfigFileWatcher() {
+		if globals.NeedsObservabilityConfigFromFile() {
 			var ocfgw *cfgowatcher.Watcher
 			if globals.ObservabilityConfigPath != "" {
 				obsCfgPath, err := filepath.Abs(globals.ObservabilityConfigPath)
@@ -147,6 +150,30 @@ func NewInstance(globals *cmd.Globals, b backend.Interface) (*Instance, error) {
 		}
 
 		broker.km = km
+	}
+
+	if globals.NeedsFilePoller() {
+		p, err := fs.NewPoller(globals.ConfigPollingFrequency, globals.Logger.Named("poller"))
+		if err != nil {
+			return nil, fmt.Errorf("error creating file poller: %w", err)
+		}
+
+		if globals.NeedsBrokerConfigFromFile() {
+			configPath, err := filepath.Abs(globals.BrokerConfigPath)
+			if err != nil {
+				return nil, fmt.Errorf("error resolving to absolute path %q: %w", globals.BrokerConfigPath, err)
+			}
+
+			globals.Logger.Debugw("Creating poller for broker configuration", zap.String("file", configPath))
+			bcfgp, err := cfgbpoller.NewPoller(p, configPath, globals.Logger.Named("cfgpoller"))
+			if err != nil {
+				return nil, fmt.Errorf("error adding broker poller for %q: %w", configPath, err)
+			}
+
+			broker.bcp = bcfgp
+		}
+
+		// TODO add observability poller
 	}
 
 	return broker, nil
@@ -213,6 +240,21 @@ func (i *Instance) Start(inctx context.Context) error {
 		if err = i.ocw.Start(ctx); err != nil {
 			return fmt.Errorf("could not start observability configuration watcher: %w", err)
 		}
+	}
+
+	if i.bcp != nil {
+		i.logger.Debug("Adding config poller callbacks")
+		i.bcp.AddCallback(i.ingest.UpdateFromConfig)
+		i.bcp.AddCallback(i.subscription.UpdateFromConfig)
+
+		// Start the configuration poller for brokers.
+		// There is no need to add it to the wait group
+		// since it cleanly exits when context is done.
+		i.logger.Debug("Starting broker configuration watcher")
+		if err = i.bcp.Start(ctx); err != nil {
+			return fmt.Errorf("could not start broker configuration poller: %w", err)
+		}
+
 	}
 
 	// Start controller only if kubernetes informers are configured

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -153,7 +153,7 @@ func NewInstance(globals *cmd.Globals, b backend.Interface) (*Instance, error) {
 	}
 
 	if globals.NeedsFilePoller() {
-		p, err := fs.NewPoller(globals.ConfigPollingFrequency, globals.Logger.Named("poller"))
+		p, err := fs.NewPoller(globals.ConfigPollingPeriod, globals.Logger.Named("poller"))
 		if err != nil {
 			return nil, fmt.Errorf("error creating file poller: %w", err)
 		}

--- a/pkg/broker/cmd/globals.go
+++ b/pkg/broker/cmd/globals.go
@@ -35,7 +35,7 @@ type Globals struct {
 	Port                    int    `help:"HTTP Port to listen for CloudEvents." env:"PORT" default:"8080"`
 	BrokerName              string `help:"Broker instance name. When running at Kubernetes should be set to RedisBroker name" env:"BROKER_NAME" default:"${hostname}"`
 
-	ConfigPollingFrequency string `help:"Freqency polling for the configuration files using ISO8601. A zero duration disables configuration by polling." env:"CONFIG_POLLING_FREQUENCY" default:"PT0S"`
+	ConfigPollingPeriod string `help:"Period for polling the configuration files using ISO8601. A zero duration disables configuration by polling." env:"CONFIG_POLLING_PERIOD" default:"PT0S"`
 
 	// Kubernetes parameters
 	KubernetesNamespace                  string `help:"Namespace where the broker is running." env:"KUBERNETES_NAMESPACE"`
@@ -85,8 +85,8 @@ func (s *Globals) Validate() error {
 		msg = append(msg, "Kubernetes namespace must not be informed when no Secrets/ConfigMaps are watched.")
 	}
 
-	if s.ConfigPollingFrequency != "" {
-		p, err := period.Parse(s.ConfigPollingFrequency)
+	if s.ConfigPollingPeriod != "" {
+		p, err := period.Parse(s.ConfigPollingPeriod)
 		if err != nil {
 			msg = append(msg, fmt.Sprintf("Polling frequency cannot is not an ISO8601 duration: %v", err))
 		} else {

--- a/pkg/broker/cmd/globals.go
+++ b/pkg/broker/cmd/globals.go
@@ -33,7 +33,8 @@ type Globals struct {
 	ObservabilityConfigPath string `help:"Path to observability configuration file." env:"OBSERVABILITY_CONFIG_PATH"`
 	Port                    int    `help:"HTTP Port to listen for CloudEvents." env:"PORT" default:"8080"`
 	BrokerName              string `help:"Broker instance name. When running at Kubernetes should be set to RedisBroker name" env:"BROKER_NAME" default:"${hostname}"`
-	// InstanceID              string `help:"Running process instance identifier. When running at Kubernetes should be set to the Pod name" env:"INSTANCE_ID" default:"${unique_id}"`
+
+	ConfigPollingFrequency string `help:"Freqency polling for the configuration files using ISO8601. A zero duration disables configuration by polling." env:"CONFIG_POLLING_FREQUENCY" default:"PT0S"`
 
 	// Kubernetes parameters
 	KubernetesNamespace                  string `help:"Namespace where the broker is running." env:"KUBERNETES_NAMESPACE"`

--- a/pkg/common/fs/poller.go
+++ b/pkg/common/fs/poller.go
@@ -1,0 +1,112 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	dateperiod "github.com/rickb777/date/period"
+	"go.uber.org/zap"
+)
+
+type PollerCallback func(content []byte)
+
+type Poller interface {
+	Add(path string, cb PollerCallback) error
+	Start(ctx context.Context)
+}
+
+type pollFile struct {
+	cbs            []PollerCallback
+	cachedContents []byte
+}
+
+type poller struct {
+	polledFiles map[string]pollFile
+
+	period dateperiod.Period
+	m      sync.RWMutex
+	start  sync.Once
+	logger *zap.SugaredLogger
+}
+
+func NewPoller(period string, logger *zap.SugaredLogger) (Poller, error) {
+	p, err := dateperiod.Parse(period)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse %q as polling period: %w", period, err)
+	}
+	return &poller{
+		period: p,
+	}, nil
+}
+
+func (p *poller) Add(path string, cb PollerCallback) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("error resolving to absoluthe path %q: %w", path, err)
+	}
+
+	if absPath != path {
+		return fmt.Errorf("configuration path %q needs to be abstolute", path)
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.logger.Infow("Adding file to poller", zap.String("file", path))
+	if _, ok := p.polledFiles[path]; !ok {
+		p.polledFiles[path] = pollFile{cbs: []PollerCallback{cb}}
+		return nil
+	}
+
+	pf := p.polledFiles[path]
+	pf.cbs = append(pf.cbs, cb)
+	p.polledFiles[path] = pf
+
+	return nil
+}
+
+func (p *poller) Start(ctx context.Context) {
+	p.start.Do(func() {
+
+		ticker := time.NewTicker(p.period.DurationApprox())
+		// Do not block, exit on context done.
+		go func() {
+			for {
+
+				p.poll()
+
+				select {
+				case <-ctx.Done():
+					p.logger.Debug("Exiting file poller process")
+					return
+				case <-ticker.C:
+					// file polling at the start of the loop
+				}
+			}
+		}()
+	})
+}
+
+func (p *poller) poll() {
+	p.m.RLock()
+	defer p.m.RUnlock()
+
+	for file, pf := range p.polledFiles {
+		b, err := os.ReadFile(file)
+		if err != nil {
+			p.logger.Errorw("cannot poll file", zap.String("filed", file), zap.Error(err))
+		}
+
+		if !bytes.Equal(pf.cachedContents, b) {
+			pf.cachedContents = b
+			for _, cb := range pf.cbs {
+				cb(b)
+			}
+		}
+	}
+}

--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -49,7 +49,7 @@ func New(inctx context.Context, logger *zap.SugaredLogger, be backend.Interface)
 }
 
 func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
-	m.logger.Debug("Updating configuration")
+	m.logger.Info("Updating subscriptions configuration")
 	m.m.Lock()
 	defer m.m.Unlock()
 


### PR DESCRIPTION
This is very dirty at the moment, but need to be merged to early test `tmctl` on windows systems.

Will not close the issue #93  since:

- It needs heavy refactoring.
- Observability configuration is not polled.

