### PR TITLE
releases: create release archives instead of binary releases

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -41,7 +41,7 @@ jobs:
           images: gcr.io/triggermesh/memory-broker
           tags: |
             type=semver,pattern={{raw}}
-            latest
+            type=sha
 
       - name: Build and push memory-broker image
         uses: docker/build-push-action@v3
@@ -59,7 +59,7 @@ jobs:
           images: gcr.io/triggermesh/redis-broker
           tags: |
             type=semver,pattern={{raw}}
-            latest
+            type=sha
 
       - name: Build and push redis-broker image
         uses: docker/build-push-action@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,10 +35,12 @@ builds:
 
 archives:
   - id: default
-    format: binary
-    name_template: '{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     replacements:
       darwin: macOS
+    format_overrides:
+      - goos: windows
+        format: zip
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
as a result we have
1. lesser number of assets attached to releases
2. downloads are smaller as they are compressed files 
3. `latest` tag applied only to releases