### PR TITLE
Make durations backwards compatible

### DIFF
--- a/pkg/backend/impl/memory/cmd.go
+++ b/pkg/backend/impl/memory/cmd.go
@@ -24,7 +24,17 @@ func (ma *MemoryArgs) Validate() error {
 	if ma.ProduceTimeout != "" {
 		p, err := period.Parse(ma.ProduceTimeout)
 		if err != nil {
-			msg = append(msg, fmt.Sprintf("Produce timeout is not an ISO8601 duration: %v", err))
+			// try to parse go duration for backwards compatibility.
+			gd, gderr := time.ParseDuration(ma.ProduceTimeout)
+			if gderr != nil {
+				// go time parsing failed, we assume that the incoming parameter was ISO8601
+				// for the error message.
+				msg = append(msg, fmt.Sprintf("Produce timeout is not an ISO8601 duration: %v", err))
+			} else {
+				// configure using go time
+				// TODO cast a warning.
+				ma.ProduceTimeoutDuration = gd
+			}
 		} else {
 			ma.ProduceTimeoutDuration = p.DurationApprox()
 		}

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -152,7 +152,7 @@ func NewInstance(globals *cmd.Globals, b backend.Interface) (*Instance, error) {
 		broker.km = km
 
 	case cmd.ConfigMethodFilePoller:
-		p, err := fs.NewPoller(globals.ConfigPollingPeriod, globals.Logger.Named("poller"))
+		p, err := fs.NewPoller(globals.PollingPeriod, globals.Logger.Named("poller"))
 		if err != nil {
 			return nil, fmt.Errorf("error creating file poller: %w", err)
 		}

--- a/pkg/broker/cmd/globals.go
+++ b/pkg/broker/cmd/globals.go
@@ -78,7 +78,17 @@ func (s *Globals) Validate() error {
 	if s.ConfigPollingPeriod != "" {
 		p, err := period.Parse(s.ConfigPollingPeriod)
 		if err != nil {
-			msg = append(msg, fmt.Sprintf("Polling frequency is not an ISO8601 duration: %v", err))
+			// try to parse go duration for backwards compatibility.
+			gd, gderr := time.ParseDuration(s.ConfigPollingPeriod)
+			if gderr != nil {
+				// go time parsing failed, we assume that the incoming parameter was ISO8601
+				// for the error message.
+				msg = append(msg, fmt.Sprintf("Config polling period is not an ISO8601 duration: %v", err))
+			} else {
+				// configure using go time
+				// TODO cast a warning.
+				s.PollingPeriod = gd
+			}
 		} else {
 			s.PollingPeriod = p.DurationApprox()
 		}


### PR DESCRIPTION
Last PR introduced an incompatible change regarding durations, that need to be informed using ISO8601.
This PR allows the previous go duration format to also be specified.