### PR TITLE
Add support for Redis clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ REDIS_TLS_SKIP_VERIFY=true \
 go run ./cmd/redis-broker start
 ```
 
+Note: when using a Redis cluster provide a comma separated list of nodes at `REDIS_CLUSTER_ADDRESSES` instead of the `REDIS_ADDRESS` parameter.
+
 ## Memory
 
 ```console
@@ -200,7 +202,8 @@ config-polling-period                 | CONFIG_POLLING_PERIOD    | PT0S | ISO860
 broker-config                 | BROKER_CONFIG    | | JSON representation of broker configuration. Enabling it will disable other configuration methods.
 observability-config                 | BROKER_CONFIG    |  | JSON representation of observability configuration. Enabling it will disable other configuration methods.
 observability-metrics-domain          | OBSERVABILITY_CONFIG  | triggermesh.io/eventing | Domain to be used for some metrics reporters.
-redis.address             | REDIS_ADDRESS                   | 0.0.0.0:6379 | Redis address.
+redis.address             | REDIS_ADDRESS                   | 0.0.0.0:6379 | Redis address for standalone instances.
+redis.cluster-addresses   | REDIS_CLUSTER_ADDRESSES         | | Comma separated list of redis addresses for clustered instances.
 redis.username            | REDIS_USERNAME                  | | Redis username.
 redis.password            | REDIS_PASSWORD                  | | Redis password.
 redis.database            | REDIS_DATABASE                  | 0 | Database ordinal at Redis.

--- a/pkg/backend/impl/redis/cmd.go
+++ b/pkg/backend/impl/redis/cmd.go
@@ -9,7 +9,9 @@ import (
 )
 
 type RedisArgs struct {
-	Address       string `help:"Redis address." env:"ADDRESS" default:"0.0.0.0:6379"`
+	Address          string   `help:"Redis address." env:"ADDRESS" default:"0.0.0.0:6379"`
+	ClusterAddresses []string `help:"Redis address." env:"CLUSTER_ADDRESSES"`
+
 	Username      string `help:"Redis username." env:"USERNAME"`
 	Password      string `help:"Redis password." env:"PASSWORD"`
 	Database      int    `help:"Database ordinal at Redis." env:"DATABASE" default:"0"`
@@ -27,7 +29,10 @@ type RedisArgs struct {
 func (ra *RedisArgs) Validate() error {
 	msg := []string{}
 
-	// TODO add validations
+	if len(ra.ClusterAddresses) != 0 &&
+		ra.Address != "" {
+		msg = append(msg, "Only one of address (standalone) or cluster addresses (cluster) arguments must be provided.")
+	}
 
 	if len(msg) == 0 {
 		return nil

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -36,7 +36,7 @@ type subscription struct {
 	// stoppedCh signals when a subscription has completely finished.
 	stoppedCh chan struct{}
 
-	client *goredis.Client
+	client goredis.Cmdable
 	logger *zap.SugaredLogger
 }
 


### PR DESCRIPTION
Redis Clusters need a different client, and is able to configure multiple addresses.

Although the previous client was working for some cluster scenarios we got a user reporting that it did not work for them:

```log
{"level":"error","ts":1677378306.6000555,"logger":"ingest","caller":"ingest/ingest.go:125","msg":"Could not produce CloudEvent to broker","error":"could not produce CloudEvent to backend: MOVED 7265 10.0.10.255:6379","stacktrace":"github.com/triggermesh/brokers/pkg/ingest.(*Instance).cloudEventsHandler\n\t/workspace/pkg/ingest/ingest.go:125\nreflect.Value.call\n\t/usr/local/go/src/reflect/value.go:556\nreflect.Value.Call\n\t/usr/local/go/src/reflect/value.go:339\ngithub.com/cloudevents/sdk-go/v2/client.(*receiverFn).invoke\n\t/go/pkg/mod/github.com/cloudevents/sdk-go/v2@v2.13.0/client/receiver.go:91\ngithub.com/cloudevents/sdk-go/v2/client.(*receiveInvoker).Invoke.func2\n\t/go/pkg/mod/github.com/cloudevents/sdk-go/v2@v2.13.0/client/invoker.go:85\ngithub.com/cloudevents/sdk-go/v2/client.(*receiveInvoker).Invoke\n\t/go/pkg/mod/github.com/cloudevents/sdk-go/v2@v2.13.0/client/invoker.go:88\ngithub.com/cloudevents/sdk-go/v2/client.(*ceClient).StartReceiver.func2.1\n\t/go/pkg/mod/github.com/cloudevents/sdk-go/v2@v2.13.0/client/client.go:253\ngithub.com/cloudevents/sdk-go/v2/client.(*ceClient).StartReceiver.func2.2\n\t/go/pkg/mod/github.com/cloudevents/sdk-go/v2@v2.13.0/client/client.go:265"}
```

This PR adds the new client when a cluster address is used.
