### PR TITLE
switch back to docker builds

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -11,10 +11,6 @@ on:
       - 'v*'
   pull_request:
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
   build:
     name: Build binaries
@@ -30,7 +26,7 @@ jobs:
         go-version: '1.19'
 
     - name: Go caches
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod
@@ -47,6 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
+    strategy:
+      fail-fast: false
+      matrix:
+        brokers: [memory-broker, redis-broker]
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -57,7 +58,7 @@ jobs:
         go-version: '1.19'
 
     - name: Go caches
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod
@@ -65,8 +66,9 @@ jobs:
         restore-keys: |
           ${{ github.job }}-${{ runner.os }}-go-
 
-    - name: Installing ko
-      run: go install github.com/google/ko@v0.11.2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to Docker Hub
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
@@ -75,6 +77,27 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: DockerHub metadata
+      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+      id: docker-meta
+      uses: docker/metadata-action@v4
+      with:
+        images: docker.io/triggermesh/${{ matrix.brokers }}
+        tags: |
+          type=semver,pattern={{raw}}
+          type=sha,prefix=,suffix=,format=long
+
+    - name: Build and push images to docker.io
+      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
+        file: cmd/${{ matrix.brokers }}/Dockerfile
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.docker-meta.outputs.tags }}
+        labels: ${{ steps.docker-meta.outputs.labels }}
+
     - name: Login to GCR
       uses: docker/login-action@v2
       with:
@@ -82,27 +105,24 @@ jobs:
         username: _json_key
         password: ${{ secrets.GCLOUD_SERVICEACCOUNT_KEY }}
 
-    - name: Set IMAGE_TAG
-      id: image-tag
-      run: |
-        IMAGE_TAG=${GITHUB_SHA}
-        [[ ${GITHUB_REF_TYPE} == "tag" ]] && IMAGE_TAG=${GITHUB_REF_NAME}
-        echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+    - name: GCR metadata
+      id: gcr-meta
+      uses: docker/metadata-action@v4
+      with:
+        images: gcr.io/triggermesh/${{ matrix.brokers }}
+        tags: |
+          type=semver,pattern={{raw}}
+          type=sha,prefix=,suffix=,format=long
 
-    - name: Publish container images to DockerHub
-      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-      env:
-        KO_DOCKER_REPO: docker.io/triggermesh
-        KOFLAGS: --jobs=4 --platform=linux/amd64,linux/arm64,linux/ppc64le --push=${{ github.event_name != 'pull_request' }}
-      run: |
-        IMAGE_TAG=${{ steps.image-tag.outputs.IMAGE_TAG }} make release
-
-    - name: Publish container images to GCR
-      env:
-        KO_DOCKER_REPO: gcr.io/triggermesh
-        KOFLAGS: --jobs=4 --platform=linux/amd64,linux/arm64,linux/ppc64le --push=${{ github.event_name != 'pull_request' }}
-      run: |
-        IMAGE_TAG=${{ steps.image-tag.outputs.IMAGE_TAG }} make release
+    - name: Build and push image to gcr.io
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: linux/amd64
+        file: cmd/${{ matrix.brokers }}/Dockerfile
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.gcr-meta.outputs.tags }}
+        labels: ${{ steps.gcr-meta.outputs.labels }}
 
   release:
     name: Create Release

--- a/cmd/memory-broker/Dockerfile
+++ b/cmd/memory-broker/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.19 as builder
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=0 go build -a -o memory-broker ./cmd/memory-broker/main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/memory-broker .
+USER 65532:65532
+
+ENTRYPOINT ["/memory-broker"]

--- a/cmd/redis-broker/Dockerfile
+++ b/cmd/redis-broker/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.19 as builder
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=0 go build -a -o redis-broker ./cmd/redis-broker/main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/redis-broker .
+USER 65532:65532
+
+ENTRYPOINT ["/redis-broker"]


### PR DESCRIPTION
Switching back to docker buildx for the builds because ko builds put the binary at the path `/ko-app/` which introduces an incompatibility with tmctl which expects the binary at `/`

As a result the multi-platform image builds take a long time.

Closes #134 