### PR TITLE
Add redis backend TLS auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ go run ./cmd/redis-broker start \
 
 ### TLS Enabled Redis
 
-If the Redis instance is exposed using TLS, it must enabled at the broker config via `redis.tls-enabled` flag. When using self-signed certificates `redis.tls-skip-verify` must be used.
+If the Redis instance is exposed using TLS, it must enabled at the broker config via `redis.tls-enabled` flag. For self-signed certificates you can inform them with `redis.tls-ca-certificate` or skip verification (not recommended) with `redis.tls-skip-verify`.
 
 ```console
 go run ./cmd/redis-broker start \
@@ -107,6 +107,21 @@ go run ./cmd/redis-broker start \
   --redis.tls-enabled  \
   --redis.tls-ca-certificate="-----BEGIN CERTIFICATE-----abc123-----END CERTIFICATE-----" \
   --redis.address "tls.self.signed.redis.server:25102" \
+  --broker-config-path .local/broker-config.yaml
+```
+
+When configuring TLS certificates for Redis authentication, make use of `redis.tls-certificate` and `redis.tls-key`.
+
+```console
+go run ./cmd/redis-broker start \
+  --redis.tls-enabled  \
+  --redis.tls-certificate='-----BEGIN CERTIFICATE-----
+deadbeef..
+-----END CERTIFICATE-----' \
+  --redis.tls-key='-----BEGIN PRIVATE KEY-----
+c0ff33...
+-----END PRIVATE KEY-----' \
+  --redis.address "tls.redis.server:25102" \
   --broker-config-path .local/broker-config.yaml
 ```
 
@@ -210,6 +225,8 @@ redis.database            | REDIS_DATABASE                  | 0 | Database ordin
 redis.tls-enabled         | REDIS_TLS_ENABLED               | false | TLS enablement for Redis connection.
 redis.tls-skip-verify     | REDIS_TLS_SKIP_VERIFY           | false | TLS skipping certificate verification.
 redis.tls-ca-certificate  | REDIS_TLS_CA_CERTIFICATE        | | TLS CA certificate used to connect to Redis.
+redis.tls-certificate     | REDIS_TLS_CERTIFICATE           | | TLS certificate used to authenticate with Redis.
+redis.tls-key             | REDIS_TLS_KEY                   | | TLS key used to authenticate with Redis.
 redis.stream              | REDIS_STREAM                    | triggermesh | Stream name that stores the broker's CloudEvents.
 redis.group               | REDIS_GROUP                     | default | Redis stream consumer group name.
 redis.stream-max-len      | REDIS_STREAM_MAX_LEN            | 1000 | Limit the number of items in a stream by trimming it. Set to 0 for unlimited.

--- a/pkg/backend/impl/redis/cmd.go
+++ b/pkg/backend/impl/redis/cmd.go
@@ -17,6 +17,8 @@ type RedisArgs struct {
 	Database         int    `help:"Database ordinal at Redis." env:"DATABASE" default:"0"`
 	TLSEnabled       bool   `help:"TLS enablement for Redis connection." env:"TLS_ENABLED" default:"false"`
 	TLSSkipVerify    bool   `help:"TLS skipping certificate verification." env:"TLS_SKIP_VERIFY" default:"false"`
+	TLSCertificate   string `help:"TLS Certificate to connect to Redis." env:"TLS_CERTIFICATE"`
+	TLSKey           string `help:"TLS Certificate key to connect to Redis." env:"TLS_KEY"`
 	TLSCACertificate string `help:"CA Certificate to connect to Redis." name:"tls-ca-certificate" env:"TLS_CA_CERTIFICATE"`
 
 	Stream string `help:"Stream name that stores the broker's CloudEvents." env:"STREAM" default:"triggermesh"`
@@ -39,6 +41,11 @@ func (ra *RedisArgs) Validate() error {
 
 	if ra.TLSCACertificate != "" && ra.TLSSkipVerify {
 		msg = append(msg, "only one of skip verify or CA certificate can be informed")
+	}
+
+	if (ra.TLSCertificate != "" || ra.TLSKey != "") &&
+		(ra.TLSCertificate == "" || ra.TLSKey == "") {
+		msg = append(msg, "TLS authentication requires Certificate and Key to be informed")
 	}
 
 	if len(msg) == 0 {


### PR DESCRIPTION
Adding capabilities to use TLS authentication against a user provided Redis instance.

Related to https://github.com/triggermesh/brokers/issues/129