### PR TITLE
Redis: make redis tracking id opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ redis.tls-skip-verify     | REDIS_TLS_SKIP_VERIFY           | false | TLS skippi
 redis.tls-ca-certificate  | REDIS_TLS_CA_CERTIFICATE        | | TLS CA certificate used to connect to Redis.
 redis.tls-certificate     | REDIS_TLS_CERTIFICATE           | | TLS certificate used to authenticate with Redis.
 redis.tls-key             | REDIS_TLS_KEY                   | | TLS key used to authenticate with Redis.
+redis.tracking-id-enabled | REDIS_TRACKING_ID_ENABLED       | false | Adds the Redis ID for the event as `triggermeshbackendid` CloudEvents attribute.
 redis.stream              | REDIS_STREAM                    | triggermesh | Stream name that stores the broker's CloudEvents.
 redis.group               | REDIS_GROUP                     | default | Redis stream consumer group name.
 redis.stream-max-len      | REDIS_STREAM_MAX_LEN            | 1000 | Limit the number of items in a stream by trimming it. Set to 0 for unlimited.

--- a/pkg/backend/impl/redis/cmd.go
+++ b/pkg/backend/impl/redis/cmd.go
@@ -26,7 +26,8 @@ type RedisArgs struct {
 	// Instance at the Redis stream consumer group. Copied from the InstanceName at the global args.
 	Instance string `kong:"-"`
 
-	StreamMaxLen int `help:"Limit the number of items in a stream by trimming it. Set to 0 for unlimited." env:"STREAM_MAX_LEN" default:"1000"`
+	StreamMaxLen      int  `help:"Limit the number of items in a stream by trimming it. Set to 0 for unlimited." env:"STREAM_MAX_LEN" default:"1000"`
+	TrackingIDEnabled bool `help:"Enables adding Redis ID as a CloudEvent attribute." env:"TRACKING_ID_ENABLED" default:"false"`
 }
 
 func (ra *RedisArgs) Validate() error {

--- a/pkg/backend/impl/redis/redis.go
+++ b/pkg/backend/impl/redis/redis.go
@@ -226,6 +226,8 @@ func (s *redis) Subscribe(name string, ccb backend.ConsumerDispatcher) error {
 		name:     name,
 		group:    group,
 
+		trackingEnabled: s.args.TrackingIDEnabled,
+
 		// caller's callback for dispatching events from Redis.
 		ccbDispatch: ccb,
 


### PR DESCRIPTION
When subscribing to a Redis backend, the underlying ID is set as a CloudEvents attribute.

This has been reported as _not desired_ so I am making it opt-in.