### PR TITLE
Support Replays on RedisBroker

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,41 @@
-# Configuration
+# (Draft) Configuration
+
+## Broker Configuration
+
+```yaml
+triggers: <TRIGGER LIST>
+  <TRIGGER-NAME>:
+    filters:
+    <FILTERS ARRAY>
+    bounds:
+      startId: <BACKEND ID FOR THE FIRST ELEMENT TO RECEIVE>
+      endId: <BACKEND ID FOR THE LAST ELEMENT TO RECEIVE>
+    target:
+      url: <DESTINATION URL>
+    deliveryOptions:
+      retry: <RETRIES WHEN FAILED TO DELIVER>
+      backoffDelay: <RETRY DELAY FACTOR AS ISO 8601 DURATION>
+      backoffPolicy: <RETRY BACKOFF POLICY>
+      deadLetterURL: <DEAD LETTER URL>
+```
+
+The configuration's root `triggers` element contains a set of triggers listed under their names:
+
+```yaml
+triggers:
+  some-trigger:
+    ...
+  some-other-trigger:
+    ...
+```
+
+Triggers configure subscriptions from the broker to a target, using optional filter and message bounds.
+
+- Target: is the URL where events will be sent.
+- Filter: use CloudEvents attribute filters
+- Bounds: use an `startId` and `endId` bound value.
+
+A bounded trigger can be created to replay events. Only Redis broker is capable of replaying events, and bounds are set after the internal Unix timestamp with millisecond precision (example `1686851697104-0`). Bounds for the redis broker are exclusive, start and end IDs are not sent to the target.
 
 ## Broker Configuration Examples
 
@@ -16,10 +53,29 @@ triggers:
         type: example.type
     target:
       url: http://localhost:9000
-      deliveryOptions:
-        retry: 2
-        backoffDelay: PT5S
-        backoffPolicy: linear
+    deliveryOptions:
+      retry: 2
+      backoffDelay: PT5S
+      backoffPolicy: linear
+```
+
+## Example Replay
+
+```yaml
+triggers:
+  replay1:
+    bounds:
+      startId: 1686851639344-0
+      endId: 1686851697104-0
+    filters:
+    - exact:
+        type: example.type
+    target:
+      url: http://localhost:9099
+    deliveryOptions:
+      retry: 1
+      backoffDelay: PT5S
+      backoffPolicy: linear
 ```
 
 ## Observability Examples

--- a/pkg/backend/impl/memory/memory.go
+++ b/pkg/backend/impl/memory/memory.go
@@ -59,11 +59,11 @@ func (s *memory) Produce(ctx context.Context, event *cloudevents.Event) error {
 	return nil
 }
 
-func (s *memory) SubscribeBounded(name, startDate, endDate string, ccb backend.ConsumerDispatcher) error {
-	return nil
-}
+func (s *memory) Subscribe(name, startID, endID string, ccb backend.ConsumerDispatcher) error {
+	if startID != "" || endID != "" {
+		return errors.New("not supported")
+	}
 
-func (s *memory) Subscribe(name string, ccb backend.ConsumerDispatcher) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.ccbs[name] = ccb

--- a/pkg/backend/impl/memory/memory.go
+++ b/pkg/backend/impl/memory/memory.go
@@ -59,6 +59,10 @@ func (s *memory) Produce(ctx context.Context, event *cloudevents.Event) error {
 	return nil
 }
 
+func (s *memory) SubscribeBounded(name, startDate, endDate string, ccb backend.ConsumerDispatcher) error {
+	return nil
+}
+
 func (s *memory) Subscribe(name string, ccb backend.ConsumerDispatcher) error {
 	s.m.Lock()
 	defer s.m.Unlock()

--- a/pkg/backend/impl/redis/redis.go
+++ b/pkg/backend/impl/redis/redis.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,8 +22,8 @@ import (
 )
 
 const (
-	// Starting point for the consumer group.
-	groupStartID = "$"
+	// Default starting point for the consumer group.
+	defaultGroupStartID = "$"
 
 	// Redis key at the message that contains the CloudEvent.
 	ceKey = "ce"
@@ -192,8 +191,8 @@ func (s *redis) Produce(ctx context.Context, event *cloudevents.Event) error {
 }
 
 // SubscribeBounded is a variant of the Subscribe function that supports bounded subscriptions.
-// It adds the option of using a startDate and endDate for the replay feature.
-func (s *redis) SubscribeBounded(name, startDate, endDate string, ccb backend.ConsumerDispatcher) error {
+// It adds the option of using a startId and endId for the replay feature.
+func (s *redis) Subscribe(name, startId, endId string, ccb backend.ConsumerDispatcher) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -206,78 +205,18 @@ func (s *redis) SubscribeBounded(name, startDate, endDate string, ccb backend.Co
 		return fmt.Errorf("subscription for %q alredy exists", name)
 	}
 
-	startDateStreamID, err := convertDateToStreamID(startDate)
-	if err != nil {
-		return fmt.Errorf("could not convert start date to stream ID: %w", err)
+	if startId == "" {
+		startId = defaultGroupStartID
 	}
 
-	endDateStreamID, err := convertDateToStreamID(endDate)
-	if err != nil {
-		return fmt.Errorf("could not convert end date to stream ID: %w", err)
-	}
-
-	// Create the consumer group for this subscription.
-	group := s.args.Group + "." + name
-	res := s.client.XGroupCreateMkStream(s.ctx, s.args.Stream, group, startDateStreamID)
-	_, err = res.Result()
-	if err != nil {
-		// Ignore errors when the group already exists.
-		if !strings.HasPrefix(err.Error(), "BUSYGROUP") {
-			return err
-		}
-		s.logger.Debug("Consumer group already exists", zap.String("group", group))
-	}
-
-	// We don't use the parent context but create a new one so that we can control
-	// how subscriptions are finished by calling cancel at our will, either when the
-	// global context is called, or when unsubscribing.
-	ctx, cancel := context.WithCancel(context.Background())
-
-	subs := subscription{
-		instance: s.args.Instance,
-		stream:   s.args.Stream,
-		name:     name,
-		group:    group,
-		endDate:  endDateStreamID,
-
-		trackingEnabled: s.args.TrackingIDEnabled,
-
-		// caller's callback for dispatching events from Redis.
-		ccbDispatch: ccb,
-
-		// cancel function let us control when we want to exit the subscription loop.
-		ctx:    ctx,
-		cancel: cancel,
-		// stoppedCh signals when a subscription has completely finished.
-		stoppedCh: make(chan struct{}),
-
-		client: s.client,
-		logger: s.logger,
-	}
-
-	s.subs[name] = subs
-	s.wgSubs.Add(1)
-	subs.start()
-
-	return nil
-}
-
-func (s *redis) Subscribe(name string, ccb backend.ConsumerDispatcher) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	// avoid subscriptions if disconnection is going on
-	if s.disconnecting {
-		return errors.New("cannot create new subscriptions while disconnecting")
-	}
-
-	if _, ok := s.subs[name]; ok {
-		return fmt.Errorf("subscription for %q alredy exists", name)
+	var exceedBoundCheck exceedBounds
+	if endId != "" {
+		exceedBoundCheck = newExceedBounds(endId)
 	}
 
 	// Create the consumer group for this subscription.
 	group := s.args.Group + "." + name
-	res := s.client.XGroupCreateMkStream(s.ctx, s.args.Stream, group, groupStartID)
+	res := s.client.XGroupCreateMkStream(s.ctx, s.args.Stream, group, startId)
 	_, err := res.Result()
 	if err != nil {
 		// Ignore errors when the group already exists.
@@ -293,10 +232,11 @@ func (s *redis) Subscribe(name string, ccb backend.ConsumerDispatcher) error {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	subs := subscription{
-		instance: s.args.Instance,
-		stream:   s.args.Stream,
-		name:     name,
-		group:    group,
+		instance:            s.args.Instance,
+		stream:              s.args.Stream,
+		name:                name,
+		group:               group,
+		checkBoundsExceeded: exceedBoundCheck,
 
 		trackingEnabled: s.args.TrackingIDEnabled,
 
@@ -376,50 +316,4 @@ func (s *redis) Probe(ctx context.Context) error {
 
 	// Add some context since Redis client sometimes is not clear about what failed.
 	return fmt.Errorf("failed probing Redis, using PING: %w", err)
-}
-
-// convertDateToStreamID converts a RFC3339 date string to a Redis Stream ID.
-// It uses the date to create a timestamp in milliseconds for the ID, and appends "-0"
-// to indicate the first event after this timestamp.
-func convertDateToStreamID(date string) (string, error) {
-	t, err := time.Parse(time.RFC3339, date)
-	if err != nil {
-		return "", err
-	}
-
-	milliseconds := t.UnixNano() / int64(time.Millisecond)
-
-	streamID := fmt.Sprintf("%d-0", milliseconds)
-	return streamID, nil
-}
-
-// compareStreamIDs compares two Redis Stream IDs (msgID and endDate) and returns true if msgID is greater than endDate.
-// Both IDs are composed of a timestamp and a sequence number, separated by a dash ("-").
-func compareStreamIDs(msgID, endDate string) (bool, error) {
-	msgIDParts := strings.Split(msgID, "-")
-	endDateParts := strings.Split(endDate, "-")
-
-	if len(msgIDParts) != 2 || len(endDateParts) != 2 {
-		return false, fmt.Errorf("invalid stream ID format")
-	}
-
-	msgIDTimestamp, err1 := strconv.ParseInt(msgIDParts[0], 10, 64)
-	endDateTimestamp, err2 := strconv.ParseInt(endDateParts[0], 10, 64)
-
-	if err1 != nil || err2 != nil {
-		return false, fmt.Errorf("could not convert timestamps: %v, %v", err1, err2)
-	}
-
-	if msgIDTimestamp != endDateTimestamp {
-		return msgIDTimestamp > endDateTimestamp, nil
-	}
-
-	msgIDSeq, err1 := strconv.ParseInt(msgIDParts[1], 10, 64)
-	endDateSeq, err2 := strconv.ParseInt(endDateParts[1], 10, 64)
-
-	if err1 != nil || err2 != nil {
-		return false, fmt.Errorf("could not convert sequence numbers: %v, %v", err1, err2)
-	}
-
-	return msgIDSeq > endDateSeq, nil
 }

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -136,16 +136,16 @@ func (s *subscription) start() {
 				}
 
 				// If an end date has been specified, compare the current message ID
-				// with the end date. If the message ID is older than the end date,
+				// with the end date. If the message ID is newer than the end date,
 				// exit the loop.
 				if s.endDate != "" {
-					msgIDIsOlder, err := compareStreamIDs(msg.ID, s.endDate)
+					msgIDIsNewer, err := compareStreamIDs(msg.ID, s.endDate)
 					if err != nil {
 						s.logger.Errorw(fmt.Sprintf("could not compare the Redis message %s with the end date %s", msg.ID, s.endDate),
 							zap.Error(err))
 					}
-					exitLoop = msgIDIsOlder
-					if msgIDIsOlder {
+					exitLoop = msgIDIsNewer
+					if msgIDIsNewer {
 						break
 					}
 				}

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -26,6 +26,7 @@ type subscription struct {
 	stream   string
 	name     string
 	group    string
+	endDate  string
 
 	trackingEnabled bool
 
@@ -66,7 +67,7 @@ func (s *subscription) start() {
 	go func() {
 		for {
 			// Check at the begining of each iteration if the exit loop flag has
-			// been signaled due to done context.
+			// been signaled due to done context or because the endDate has been reached.
 			if exitLoop {
 				break
 			}
@@ -132,6 +133,15 @@ func (s *subscription) start() {
 					}
 
 					continue
+				}
+
+				// If an end date has been specified, compare the current message ID
+				// with the end date. If the message ID is greater than the end date,
+				// set the exitLoop flag to true to stop processing further messages.
+				if s.endDate != "" {
+					if msg.ID > s.endDate {
+						exitLoop = true
+					}
 				}
 
 				if s.trackingEnabled {

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -136,15 +136,18 @@ func (s *subscription) start() {
 				}
 
 				// If an end date has been specified, compare the current message ID
-				// with the end date. If the message ID is greater than the end date,
-				// set the exitLoop flag to true to stop processing further messages.
+				// with the end date. If the message ID is older than the end date,
+				// exit the loop.
 				if s.endDate != "" {
-					msgIDIsGreater, err := compareStreamIDs(msg.ID, s.endDate)
+					msgIDIsOlder, err := compareStreamIDs(msg.ID, s.endDate)
 					if err != nil {
 						s.logger.Errorw(fmt.Sprintf("could not compare the Redis message %s with the end date %s", msg.ID, s.endDate),
 							zap.Error(err))
 					}
-					exitLoop = msgIDIsGreater
+					exitLoop = msgIDIsOlder
+					if msgIDIsOlder {
+						break
+					}
 				}
 
 				if s.trackingEnabled {

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -139,9 +139,12 @@ func (s *subscription) start() {
 				// with the end date. If the message ID is greater than the end date,
 				// set the exitLoop flag to true to stop processing further messages.
 				if s.endDate != "" {
-					if msg.ID > s.endDate {
-						exitLoop = true
+					msgIDIsGreater, err := compareStreamIDs(msg.ID, s.endDate)
+					if err != nil {
+						s.logger.Errorw(fmt.Sprintf("could not compare the Redis message %s with the end date %s", msg.ID, s.endDate),
+							zap.Error(err))
 					}
+					exitLoop = msgIDIsGreater
 				}
 
 				if s.trackingEnabled {

--- a/pkg/backend/impl/redis/subscription_test.go
+++ b/pkg/backend/impl/redis/subscription_test.go
@@ -1,0 +1,50 @@
+package redis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareStreamIDs(t *testing.T) {
+	testCases := map[string]struct {
+		currentID     string
+		endID         string
+		expectedBool  bool
+		expectedError *string
+	}{
+		"not exceeded by timestamp": {
+			currentID:    "1586657816106-0",
+			endID:        "1686657816106-0",
+			expectedBool: false,
+		},
+		"not exceeded by id in same timestamp": {
+			currentID:    "1586657816106-0",
+			endID:        "1586657816106-1",
+			expectedBool: false,
+		},
+		"exceeded by equal timestamp": {
+			currentID:    "1586657816106-0",
+			endID:        "1586657816106-0",
+			expectedBool: true,
+		},
+		"exceeded by timestamp": {
+			currentID:    "1686657816106-0",
+			endID:        "1586657816106-0",
+			expectedBool: true,
+		},
+		"equal timestamp, exceeded by id": {
+			currentID:    "1686657816106-1",
+			endID:        "1686657816106-0",
+			expectedBool: true,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			eb := newExceedBounds(tc.endID)
+			b := eb(tc.currentID)
+
+			assert.Equal(t, tc.expectedBool, b)
+		})
+	}
+}

--- a/pkg/backend/interface.go
+++ b/pkg/backend/interface.go
@@ -33,6 +33,7 @@ type Subscribable interface {
 	// processed and won't be delivered anymore.
 	Subscribe(name string, ccb ConsumerDispatcher) error
 
+	SubscribeBounded(name, startDate, endDate string, ccb ConsumerDispatcher) error
 	// Unsubscribe is a method that removes a subscription referencing
 	// it by name, returning when all pending (already read) messages
 	// have been dispatched.

--- a/pkg/backend/interface.go
+++ b/pkg/backend/interface.go
@@ -26,14 +26,15 @@ type EventProducer interface {
 	Produce(context.Context, *cloudevents.Event) error
 }
 
+type SubscribeOption func(Subscribable)
+
 type Subscribable interface {
 	// Subscribe is a method that sets up a reader that will retrieve
 	// events from the backend and pass them to the consumer dispatcher.
 	// When the consumer dispatcher returns, the message is marked as
 	// processed and won't be delivered anymore.
-	Subscribe(name string, ccb ConsumerDispatcher) error
+	Subscribe(name, startID, endID string, ccb ConsumerDispatcher) error
 
-	SubscribeBounded(name, startDate, endDate string, ccb ConsumerDispatcher) error
 	// Unsubscribe is a method that removes a subscription referencing
 	// it by name, returning when all pending (already read) messages
 	// have been dispatched.

--- a/pkg/config/broker/types.go
+++ b/pkg/config/broker/types.go
@@ -145,6 +145,34 @@ type Trigger struct {
 	Target  Target   `json:"target"`
 }
 
+type ReplayTrigger struct {
+	Filters   []Filter `json:"filters,omitempty"`
+	Target    Target   `json:"target"`
+	StartDate string   `json:"startDate"`
+	EndDate   string   `json:"endDate"`
+}
+
+type TriggerInterface interface {
+	GetTarget() Target
+	GetFilters() []Filter
+}
+
+func (t Trigger) GetTarget() Target {
+	return t.Target
+}
+
+func (t Trigger) GetFilters() []Filter {
+	return t.Filters
+}
+
+func (rt ReplayTrigger) GetTarget() Target {
+	return rt.Target
+}
+
+func (rt ReplayTrigger) GetFilters() []Filter {
+	return rt.Filters
+}
+
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 
@@ -156,9 +184,21 @@ func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	return errs.Also(ValidateSubscriptionAPIFiltersList(ctx, t.Filters).ViaField("filters"))
 }
 
+func (t *ReplayTrigger) Validate(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+
+	if t == nil {
+		return nil
+	}
+	errs = errs.Also(t.Target.Validate(ctx)).ViaField("target")
+
+	return errs.Also(ValidateSubscriptionAPIFiltersList(ctx, t.Filters).ViaField("filters"))
+}
+
 type Config struct {
-	Ingest   *Ingest            `json:"ingest,omitempty"`
-	Triggers map[string]Trigger `json:"triggers"`
+	Ingest         *Ingest                  `json:"ingest,omitempty"`
+	Triggers       map[string]Trigger       `json:"triggers"`
+	ReplayTriggers map[string]ReplayTrigger `json:"replayTriggers"`
 }
 
 func (c *Config) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/config/broker/types.go
+++ b/pkg/config/broker/types.go
@@ -145,7 +145,7 @@ type Trigger struct {
 	Target  Target   `json:"target"`
 }
 
-type ReplayTrigger struct {
+type Replay struct {
 	Filters   []Filter `json:"filters,omitempty"`
 	Target    Target   `json:"target"`
 	StartDate string   `json:"startDate"`
@@ -175,20 +175,20 @@ func (t Trigger) GetEndDate() string {
 	return ""
 }
 
-func (rt ReplayTrigger) GetTarget() Target {
-	return rt.Target
+func (r Replay) GetTarget() Target {
+	return r.Target
 }
 
-func (rt ReplayTrigger) GetFilters() []Filter {
-	return rt.Filters
+func (r Replay) GetFilters() []Filter {
+	return r.Filters
 }
 
-func (rt ReplayTrigger) GetStartDate() string {
-	return rt.StartDate
+func (r Replay) GetStartDate() string {
+	return r.StartDate
 }
 
-func (rt ReplayTrigger) GetEndDate() string {
-	return rt.EndDate
+func (r Replay) GetEndDate() string {
+	return r.EndDate
 }
 
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
@@ -202,21 +202,21 @@ func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	return errs.Also(ValidateSubscriptionAPIFiltersList(ctx, t.Filters).ViaField("filters"))
 }
 
-func (t *ReplayTrigger) Validate(ctx context.Context) *apis.FieldError {
+func (r *Replay) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 
-	if t == nil {
+	if r == nil {
 		return nil
 	}
-	errs = errs.Also(t.Target.Validate(ctx)).ViaField("target")
+	errs = errs.Also(r.Target.Validate(ctx)).ViaField("target")
 
-	return errs.Also(ValidateSubscriptionAPIFiltersList(ctx, t.Filters).ViaField("filters"))
+	return errs.Also(ValidateSubscriptionAPIFiltersList(ctx, r.Filters).ViaField("filters"))
 }
 
 type Config struct {
-	Ingest         *Ingest                  `json:"ingest,omitempty"`
-	Triggers       map[string]Trigger       `json:"triggers"`
-	ReplayTriggers map[string]ReplayTrigger `json:"replayTriggers"`
+	Ingest   *Ingest            `json:"ingest,omitempty"`
+	Triggers map[string]Trigger `json:"triggers"`
+	Replays  map[string]Replay  `json:"replays"`
 }
 
 func (c *Config) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/config/broker/types.go
+++ b/pkg/config/broker/types.go
@@ -155,6 +155,8 @@ type ReplayTrigger struct {
 type TriggerInterface interface {
 	GetTarget() Target
 	GetFilters() []Filter
+	GetStartDate() string
+	GetEndDate() string
 }
 
 func (t Trigger) GetTarget() Target {
@@ -165,12 +167,28 @@ func (t Trigger) GetFilters() []Filter {
 	return t.Filters
 }
 
+func (t Trigger) GetStartDate() string {
+	return ""
+}
+
+func (t Trigger) GetEndDate() string {
+	return ""
+}
+
 func (rt ReplayTrigger) GetTarget() Target {
 	return rt.Target
 }
 
 func (rt ReplayTrigger) GetFilters() []Filter {
 	return rt.Filters
+}
+
+func (rt ReplayTrigger) GetStartDate() string {
+	return rt.StartDate
+}
+
+func (rt ReplayTrigger) GetEndDate() string {
+	return rt.EndDate
 }
 
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -20,7 +20,8 @@ import (
 )
 
 type Subscription struct {
-	Trigger cfgbroker.Trigger
+	Trigger       cfgbroker.Trigger
+	ReplayTrigger cfgbroker.ReplayTrigger
 }
 
 type Manager struct {
@@ -94,7 +95,7 @@ func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
 	for name, replayTrigger := range c.ReplayTriggers {
 		s, ok := m.subscribers[name]
 		if !ok {
-			s := m.createSubscriber(name, replayTrigger, false)
+			s := m.createSubscriber(name, replayTrigger, true)
 			if s == nil {
 				continue
 			}
@@ -153,8 +154,7 @@ func (m *Manager) createSubscriber(name string, trigger cfgbroker.TriggerInterfa
 	}
 
 	if replay {
-		rTrigger := trigger.(cfgbroker.ReplayTrigger)
-		if err := m.backend.SubscribeBounded(name, rTrigger.StartDate, rTrigger.EndDate, s.dispatchCloudEvent); err != nil {
+		if err := m.backend.SubscribeBounded(name, trigger.GetStartDate(), trigger.GetEndDate(), s.dispatchCloudEvent); err != nil {
 			m.logger.Errorw("Could not create subscription for replay trigger", zap.String("trigger", name), zap.Error(err))
 			return nil
 		}

--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -75,7 +75,7 @@ func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
 				continue
 			}
 			m.subscribers[name] = s
-			m.logger.Infow("Subscription for replay trigger updated", zap.String("name", name))
+			m.logger.Infow("Subscription for trigger updated", zap.String("name", name))
 			continue
 		}
 

--- a/pkg/subscriptions/subscriber_test.go
+++ b/pkg/subscriptions/subscriber_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 TriggerMesh Inc.
+// Copyright 2023 TriggerMesh Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package subscriptions


### PR DESCRIPTION
This PR add support to Replays:

Example of replay events from specific start date and end date:

```
triggers:
...
replays:
  replay-test:
    startDate: 2023-06-12T09:00:00Z
    endDate: 2023-06-12T10:00:00Z
    target:
      url: http://localhost:8081
      deliveryOptions:
        retry: 5
        backoffDelay: PT5S
        backoffPolicy: constant
```