### PR TITLE
Bounds: add subscription bounds by date

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ triggers:
 triggers:
   replay1:
     bounds:
-      byID:
+      byId:
         start: 1686851639344-0
         end: 1686851697104-0
     filters:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ A bounded trigger can be created to replay events. Only Redis broker is capable 
 
 ## Broker Configuration Examples
 
-### Example 1
+### Simple 1
 
 - Only allow CloudEvents type `example.type`
 - Send to `http://localhost:9000`
@@ -59,14 +59,37 @@ triggers:
       backoffPolicy: linear
 ```
 
-## Example Replay
+## Example Replay By ID
 
 ```yaml
 triggers:
   replay1:
     bounds:
-      startId: 1686851639344-0
-      endId: 1686851697104-0
+      byID:
+        start: 1686851639344-0
+        end: 1686851697104-0
+    filters:
+    - exact:
+        type: example.type
+    target:
+      url: http://localhost:9099
+    deliveryOptions:
+      retry: 1
+      backoffDelay: PT5S
+      backoffPolicy: linear
+```
+
+## Example Replay By Date
+
+Dates must be [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) formatted up to nanoseconds.
+
+```yaml
+triggers:
+  replay1:
+    bounds:
+      byDate:
+        start: 2020-04-12T02:16:56Z
+        end: 2023-06-13T12:03:36.106+00:00
     filters:
     - exact:
         type: example.type

--- a/pkg/backend/impl/memory/memory.go
+++ b/pkg/backend/impl/memory/memory.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/triggermesh/brokers/pkg/backend"
+	"github.com/triggermesh/brokers/pkg/config/broker"
 )
 
 func New(args *MemoryArgs, logger *zap.SugaredLogger) backend.Interface {
@@ -59,9 +60,9 @@ func (s *memory) Produce(ctx context.Context, event *cloudevents.Event) error {
 	return nil
 }
 
-func (s *memory) Subscribe(name, startID, endID string, ccb backend.ConsumerDispatcher) error {
-	if startID != "" || endID != "" {
-		return errors.New("not supported")
+func (s *memory) Subscribe(name string, bounds *broker.TriggerBounds, ccb backend.ConsumerDispatcher) error {
+	if bounds != nil {
+		return errors.New("bounds not supported for memory broker")
 	}
 
 	s.m.Lock()

--- a/pkg/backend/impl/redis/redis.go
+++ b/pkg/backend/impl/redis/redis.go
@@ -329,7 +329,7 @@ func boundsResolver(bounds *broker.TriggerBounds) (startID, endID string, e erro
 	}
 
 	// Process date bounds.
-	if start := bounds.ByDate.GetStartID(); start != "" {
+	if start := bounds.ByDate.GetStart(); start != "" {
 		st, err := time.Parse(time.RFC3339Nano, start)
 		if err != nil {
 			e = fmt.Errorf("parsing bounds start date: %w", err)
@@ -337,7 +337,7 @@ func boundsResolver(bounds *broker.TriggerBounds) (startID, endID string, e erro
 		}
 		startID = strconv.FormatInt(st.UnixMilli(), 10)
 	}
-	if end := bounds.ByDate.GetEndID(); end != "" {
+	if end := bounds.ByDate.GetEnd(); end != "" {
 		en, err := time.Parse(time.RFC3339, end)
 		if err != nil {
 			e = fmt.Errorf("parsing bounds end date: %w", err)
@@ -347,10 +347,10 @@ func boundsResolver(bounds *broker.TriggerBounds) (startID, endID string, e erro
 	}
 
 	// Process ID bounds.
-	if start := bounds.ByID.GetStartID(); start != "" {
+	if start := bounds.ByID.GetStart(); start != "" {
 		startID = start
 	}
-	if end := bounds.ByID.GetEndID(); end != "" {
+	if end := bounds.ByID.GetEnd(); end != "" {
 		endID = end
 	}
 

--- a/pkg/backend/impl/redis/redis_test.go
+++ b/pkg/backend/impl/redis/redis_test.go
@@ -47,8 +47,8 @@ func TestBoundsResolver(t *testing.T) {
 		"bound by ID": {
 			bounds: &broker.TriggerBounds{
 				ByID: &broker.Bounds{
-					StartID: &tStartID,
-					EndDID:  &tEndID,
+					Start: &tStartID,
+					EndD:  &tEndID,
 				},
 			},
 			expectedStartID: tStartID,
@@ -57,8 +57,8 @@ func TestBoundsResolver(t *testing.T) {
 		"bound by Date, seconds": {
 			bounds: &broker.TriggerBounds{
 				ByDate: &broker.Bounds{
-					StartID: &tStartDateSeconds,
-					EndDID:  &tEndDateSeconds,
+					Start: &tStartDateSeconds,
+					EndD:  &tEndDateSeconds,
 				},
 			},
 			expectedStartID: tStartDateSecondsToId,
@@ -67,8 +67,8 @@ func TestBoundsResolver(t *testing.T) {
 		"bound by Date, millis": {
 			bounds: &broker.TriggerBounds{
 				ByDate: &broker.Bounds{
-					StartID: &tStartDateMillis,
-					EndDID:  &tEndDateMillis,
+					Start: &tStartDateMillis,
+					EndD:  &tEndDateMillis,
 				},
 			},
 			expectedStartID: tStartDateMillisToId,

--- a/pkg/backend/impl/redis/redis_test.go
+++ b/pkg/backend/impl/redis/redis_test.go
@@ -1,0 +1,91 @@
+package redis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/triggermesh/brokers/pkg/config/broker"
+)
+
+var (
+	tStartID = "1586657816106-1"
+	tEndID   = "1686657816106-0"
+
+	tStartDateMillis     = "2020-04-12T02:16:56.106+00:00"
+	tStartDateMillisToId = "1586657816106"
+	tEndDateMillis       = "2023-06-13T12:03:36.106+00:00"
+	tEndDateMillisToId   = "1686657816106"
+
+	tStartDateSeconds     = "2020-04-12T02:16:56Z"
+	tStartDateSecondsToId = "1586657816000"
+	tEndDateSeconds       = "2023-06-13T12:03:36+00:00"
+	tEndDateSecondsToId   = "1686657816000"
+)
+
+func TestBoundsResolver(t *testing.T) {
+	testCases := map[string]struct {
+		bounds          *broker.TriggerBounds
+		expectedStartID string
+		expectedEndID   string
+		expectedError   string
+	}{
+		"no bounds": {
+			expectedStartID: "$",
+		},
+		"no bound contents": {
+			bounds: &broker.TriggerBounds{},
+
+			expectedStartID: "$",
+		},
+		"no bound by ID": {
+			bounds: &broker.TriggerBounds{
+				ByID: &broker.Bounds{},
+			},
+			expectedStartID: "$",
+		},
+		"bound by ID": {
+			bounds: &broker.TriggerBounds{
+				ByID: &broker.Bounds{
+					StartID: &tStartID,
+					EndDID:  &tEndID,
+				},
+			},
+			expectedStartID: tStartID,
+			expectedEndID:   tEndID,
+		},
+		"bound by Date, seconds": {
+			bounds: &broker.TriggerBounds{
+				ByDate: &broker.Bounds{
+					StartID: &tStartDateSeconds,
+					EndDID:  &tEndDateSeconds,
+				},
+			},
+			expectedStartID: tStartDateSecondsToId,
+			expectedEndID:   tEndDateSecondsToId,
+		},
+		"bound by Date, millis": {
+			bounds: &broker.TriggerBounds{
+				ByDate: &broker.Bounds{
+					StartID: &tStartDateMillis,
+					EndDID:  &tEndDateMillis,
+				},
+			},
+			expectedStartID: tStartDateMillisToId,
+			expectedEndID:   tEndDateMillisToId,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			start, end, err := boundsResolver(tc.bounds)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+
+			require.Nil(t, err)
+			assert.Equal(t, tc.expectedStartID, start)
+			assert.Equal(t, tc.expectedEndID, end)
+		})
+	}
+}

--- a/pkg/backend/interface.go
+++ b/pkg/backend/interface.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/triggermesh/brokers/pkg/config/broker"
 )
 
 type Info struct {
@@ -33,7 +34,7 @@ type Subscribable interface {
 	// events from the backend and pass them to the consumer dispatcher.
 	// When the consumer dispatcher returns, the message is marked as
 	// processed and won't be delivered anymore.
-	Subscribe(name, startID, endID string, ccb ConsumerDispatcher) error
+	Subscribe(name string, bounds *broker.TriggerBounds, ccb ConsumerDispatcher) error
 
 	// Unsubscribe is a method that removes a subscription referencing
 	// it by name, returning when all pending (already read) messages

--- a/pkg/config/broker/types.go
+++ b/pkg/config/broker/types.go
@@ -144,24 +144,24 @@ type Filter struct {
 // Bounds applied to the trigger that mark the initial and final item to
 // be sent from the broker.
 type Bounds struct {
-	StartID *string `json:"startId"`
-	EndDID  *string `json:"endId"`
+	Start *string `json:"start"`
+	EndD  *string `json:"end"`
 }
 
-func (b *Bounds) GetStartID() string {
-	if b == nil || b.StartID == nil {
+func (b *Bounds) GetStart() string {
+	if b == nil || b.Start == nil {
 		return ""
 	}
 
-	return *b.StartID
+	return *b.Start
 }
 
-func (b *Bounds) GetEndID() string {
-	if b == nil || b.EndDID == nil {
+func (b *Bounds) GetEnd() string {
+	if b == nil || b.EndD == nil {
 		return ""
 	}
 
-	return *b.EndDID
+	return *b.EndD
 }
 
 type TriggerBounds struct {

--- a/pkg/config/broker/types.go
+++ b/pkg/config/broker/types.go
@@ -144,31 +144,36 @@ type Filter struct {
 // Bounds applied to the trigger that mark the initial and final item to
 // be sent from the broker.
 type Bounds struct {
-	StartID string `json:"startId"`
-	EndDID  string `json:"endId"`
+	StartID *string `json:"startId"`
+	EndDID  *string `json:"endId"`
 }
 
 func (b *Bounds) GetStartID() string {
-	if b == nil {
+	if b == nil || b.StartID == nil {
 		return ""
 	}
 
-	return b.StartID
+	return *b.StartID
 }
 
 func (b *Bounds) GetEndID() string {
-	if b == nil {
+	if b == nil || b.EndDID == nil {
 		return ""
 	}
 
-	return b.EndDID
+	return *b.EndDID
+}
+
+type TriggerBounds struct {
+	ByID   *Bounds `json:"byId,omitempty"`
+	ByDate *Bounds `json:"byDate,omitempty"`
 }
 
 type Trigger struct {
 	Filters         []Filter         `json:"filters,omitempty"`
 	Target          Target           `json:"target"`
 	DeliveryOptions *DeliveryOptions `json:"deliveryOptions,omitempty"`
-	Bounds          *Bounds          `json:"bounds,omitempty"`
+	Bounds          *TriggerBounds   `json:"bounds,omitempty"`
 }
 
 // HACK temporary to make the Delivery options move smooth,

--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -120,7 +120,7 @@ func (m *Manager) createSubscriber(name string, trigger cfgbroker.Trigger) *subs
 		return nil
 	}
 
-	if err := m.backend.Subscribe(name, trigger.Bounds.GetStartID(), trigger.Bounds.GetEndID(), s.dispatchCloudEvent); err != nil {
+	if err := m.backend.Subscribe(name, trigger.Bounds, s.dispatchCloudEvent); err != nil {
 		m.logger.Errorw("Could not create subscription for trigger", zap.String("trigger", name), zap.Error(err))
 		return nil
 	}


### PR DESCRIPTION
Subscriptions can be bounded by ID.
We are adding to the configuration interface the capability to bound by Date.