### PR TITLE
[Status]add bounded subscription status

### DIFF
--- a/pkg/backend/impl/redis/redis.go
+++ b/pkg/backend/impl/redis/redis.go
@@ -246,6 +246,9 @@ func (s *redis) Subscribe(name string, bounds *broker.TriggerBounds, ccb backend
 		// caller's callback for dispatching events from Redis.
 		ccbDispatch: ccb,
 
+		// caller's callback for setting subscription status.
+		scb: scb,
+
 		// cancel function let us control when we want to exit the subscription loop.
 		ctx:    ctx,
 		cancel: cancel,

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/triggermesh/brokers/pkg/backend"
+	goredis "github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
-	goredis "github.com/redis/go-redis/v9"
+	"github.com/triggermesh/brokers/pkg/backend"
+	"github.com/triggermesh/brokers/pkg/status"
 )
 
 const (
@@ -44,6 +45,9 @@ type subscription struct {
 
 	// caller's callback for dispatching events from Redis.
 	ccbDispatch backend.ConsumerDispatcher
+
+	// caller's callback for subscription status changes
+	scb backend.SubscriptionStatusChange
 
 	// cancel function let us control when the subscription loop should exit.
 	ctx    context.Context
@@ -152,6 +156,9 @@ func (s *subscription) start() {
 				// exit the loop.
 				if s.checkBoundsExceeded != nil {
 					if exitLoop = s.checkBoundsExceeded(msg.ID); exitLoop {
+						s.scb(&status.SubscriptionStatus{
+							Status: "Completed",
+						})
 						break
 					}
 				}

--- a/pkg/backend/impl/redis/subscription.go
+++ b/pkg/backend/impl/redis/subscription.go
@@ -157,7 +157,7 @@ func (s *subscription) start() {
 				if s.checkBoundsExceeded != nil {
 					if exitLoop = s.checkBoundsExceeded(msg.ID); exitLoop {
 						s.scb(&status.SubscriptionStatus{
-							Status: "Completed",
+							Status: status.SubscriptionStatusComplete,
 						})
 						break
 					}

--- a/pkg/ingest/ingest.go
+++ b/pkg/ingest/ingest.go
@@ -107,10 +107,10 @@ func (i *Instance) Start(ctx context.Context) error {
 	if i.statusManager != nil {
 		// Notify and defer status manager
 		i.statusManager.UpdateIngestStatus(&status.IngestStatus{
-			Status: "Running",
+			Status: status.IngestStatusReady,
 		})
 		defer i.statusManager.UpdateIngestStatus(&status.IngestStatus{
-			Status: "Closed",
+			Status: status.IngestStatusClosed,
 		})
 
 		handler = i.cloudEventsStatusManagerHandler
@@ -141,10 +141,12 @@ func (i *Instance) cloudEventsStatusManagerHandler(ctx context.Context, event cl
 	e, p := i.cloudEventsHandler(ctx, event)
 
 	t := time.Now()
-	i.statusManager.UpdateIngestStatus(&status.IngestStatus{
-		Status:       "Started",
-		LastIngested: &t,
-	})
+	if i.statusManager != nil {
+		i.statusManager.UpdateIngestStatus(&status.IngestStatus{
+			Status:       status.IngestStatusRunning,
+			LastIngested: &t,
+		})
+	}
 
 	return e, p
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,5 +1,29 @@
 package status
 
+type SubscriptionStatusChoice string
+
+const (
+	// The subscription has been created and is able to process events.
+	SubscriptionStatusReady SubscriptionStatusChoice = "Ready"
+	// The subscription has started processing events.
+	SubscriptionStatusRunning SubscriptionStatusChoice = "Running"
+	// The subscription could not be created.
+	SubscriptionStatusFailed SubscriptionStatusChoice = "Failed"
+	// The subscription will not receive further events and can be deleted.
+	SubscriptionStatusComplete SubscriptionStatusChoice = "Complete"
+)
+
+type IngestStatusChoice string
+
+const (
+	// The ingest has been created and is able to receive events.
+	IngestStatusReady IngestStatusChoice = "Ready"
+	// The ingest has started receiving events.
+	IngestStatusRunning IngestStatusChoice = "Running"
+	// The ingest has been closed.
+	IngestStatusClosed IngestStatusChoice = "Closed"
+)
+
 type Manager interface {
 	UpdateIngestStatus(is *IngestStatus)
 	EnsureSubscription(name string, ss *SubscriptionStatus)

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -99,8 +99,8 @@ func (s *Status) EqualStatus(in *Status) bool {
 }
 
 type IngestStatus struct {
-	Status  string  `json:"status"`
-	Message *string `json:"message,omitempty"`
+	Status  IngestStatusChoice `json:"status"`
+	Message *string            `json:"message,omitempty"`
 
 	// LastIngested event into the broker.
 	LastIngested *time.Time `json:"lastIngested,omitempty"`
@@ -131,8 +131,8 @@ func (is *IngestStatus) EqualStatus(in *IngestStatus) bool {
 }
 
 type SubscriptionStatus struct {
-	Status  string  `json:"status"`
-	Message *string `json:"message,omitempty"`
+	Status  SubscriptionStatusChoice `json:"status"`
+	Message *string                  `json:"message,omitempty"`
 
 	LastProcessed *time.Time `json:"lastProcessed,omitempty"`
 }

--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -86,8 +86,10 @@ func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
 			}
 
 			if m.statusManager != nil {
+				// Initial state is Ready, it changes to Running when
+				// the first event is processed.
 				m.statusManager.EnsureSubscription(name, &status.SubscriptionStatus{
-					Status: "Running",
+					Status: "Ready",
 				})
 			}
 

--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -77,7 +77,7 @@ func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
 				m.logger.Errorw(msg, zap.String("trigger", name), zap.Error(err))
 				if m.statusManager != nil {
 					m.statusManager.EnsureSubscription(name, &status.SubscriptionStatus{
-						Status:  "Failed",
+						Status:  status.SubscriptionStatusFailed,
 						Message: &msg,
 					})
 				}
@@ -89,7 +89,7 @@ func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
 				// Initial state is Ready, it changes to Running when
 				// the first event is processed.
 				m.statusManager.EnsureSubscription(name, &status.SubscriptionStatus{
-					Status: "Ready",
+					Status: status.SubscriptionStatusReady,
 				})
 			}
 

--- a/pkg/subscriptions/subscriber.go
+++ b/pkg/subscriptions/subscriber.go
@@ -100,6 +100,7 @@ func (s *subscriber) dispatchCloudEvent(event *cloudevents.Event) {
 		defer func() {
 			t := time.Now()
 			s.statusManager.EnsureSubscription(s.name, &status.SubscriptionStatus{
+				Status:        "Running",
 				LastProcessed: &t,
 			})
 		}()

--- a/pkg/subscriptions/subscriber.go
+++ b/pkg/subscriptions/subscriber.go
@@ -99,8 +99,8 @@ func (s *subscriber) dispatchCloudEvent(event *cloudevents.Event) {
 	if s.statusManager != nil {
 		defer func() {
 			t := time.Now()
-			s.statusManager.EnsureSubscription(s.name, &status.SubscriptionStatus{
-				Status:        "Running",
+			s.statusChange(&status.SubscriptionStatus{
+				Status:        status.SubscriptionStatusRunning,
 				LastProcessed: &t,
 			})
 		}()


### PR DESCRIPTION
All subscriptions start as `Ready` then when the first event arrives are set to `Running`.
Subscriptions with bounded definitions are started as `Ready`, set to `Running` and finish as `Complete`