### PR TITLE
[Status]Fix deadlock at status update

### DIFF
--- a/pkg/subscriptions/manager.go
+++ b/pkg/subscriptions/manager.go
@@ -73,7 +73,7 @@ func (m *Manager) UpdateFromConfig(c *cfgbroker.Config) {
 		if !ok {
 			s, err := m.createSubscriber(name, trigger)
 			if err != nil {
-				msg := "Failed to create trigger stats reporter"
+				msg := "Failed to create trigger subscription"
 				m.logger.Errorw(msg, zap.String("trigger", name), zap.Error(err))
 				if m.statusManager != nil {
 					m.statusManager.EnsureSubscription(name, &status.SubscriptionStatus{


### PR DESCRIPTION
The status reconcile cycle acquires a lock at its body.
It can also me invoked via a channel.
The channel sender caller also  acquires the lock, and if the channel is full, it will deadlock.

This PR fixes the issue.