### PR TITLE
[Status]restructure status with backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ kubernetes-broker-config-secret-key   | KUBERNETES_BROKER_CONFIG_SECRET_KEY  | |
 kubernetes-observability-configmap-name  | KUBERNETES_OBSERVABILITY_CONFIGMAP_NAME || ConfigMap object name that contains the observability configuration.
 kubernetes-status-configmap-name | KUBERNETES_STATUS_CONFIGMAP_NAME || ConfigMap object name where the broker instance should write its status.
 kubernetes-status-configmap-key | KUBERNETES_STATUS_CONFIGMAP_KEY | status | ConfigMap object key where the broker instance should write its status.
-kubernetes-status-resync-period | KUBERNETES_STATUS_RESYNC_PERIOD | PT10S | Period for running pending status write checks using ISO8601.
-kubernetes-status-cache-expiration | KUBERNETES_STATUS_CACHE_EXPIRATION | PT1M | Time to wait without forcing a status write to the ConfigMap using ISO8601.
+status-reporter-resync-check-period | STATUS_REPORTER_RESYNC_CHECK_PERIOD | PT10S | Period for running status checks for pending changes, using ISO8601.
+status-reporter-resync-force-period | STATUS_REPORTER_RESYNC_FORCE_PERIOD | PT1M | Period for running status resync cycles that force status writes, using ISO8601.
 config-polling-period                 | CONFIG_POLLING_PERIOD    | PT0S | ISO8601 duration for config polling. Disabled if PT0S. Enabling it will disable other configuration methods.
 broker-config                 | BROKER_CONFIG    | | JSON representation of broker configuration. Enabling it will disable other configuration methods.
 observability-config                 | BROKER_CONFIG    |  | JSON representation of observability configuration. Enabling it will disable other configuration methods.

--- a/pkg/common/kubernetes/status/status.go
+++ b/pkg/common/kubernetes/status/status.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -15,9 +13,7 @@ import (
 	"github.com/triggermesh/brokers/pkg/status"
 )
 
-const ConfigMapKey = "status"
-
-type kubernetesManager struct {
+type kubernetesBackend struct {
 	// Instance must be unique for every instance of the broker, it will
 	// be used as the root element for the status reporting structure.
 	instance string
@@ -26,33 +22,8 @@ type kubernetesManager struct {
 	key   client.ObjectKey
 	cmkey string
 
-	// Cached structure for the status that avoids trying
-	// rewrites when there are no status changes.
-	//
-	// The cached structure will be considered stale after some
-	// configurable duration.
-	//
-	// lastStatusWrite checkpoints the last time the ConfigMap was written, and will be
-	// combined with cacheExpiration to calculate cache expiration
-	cached          *status.Status
-	cacheExpiration time.Duration
-	lastStatusWrite time.Time
-
-	// The kubernetes status manager will run reconciling cycles according to the
-	// resyncPeriod duration. If the status cache has expired, the ConfigMap will be
-	// re-written by this reconciling process.
-	//
-	// pendingWrite is a flag set when a status change must be written at the next
-	// reconciliation, no matter if the cached status is stale or not.
-	//
-	// A reconcile cycle can be explicitly run using the chReconcile channel.
-	resyncPeriod time.Duration
-	pendingWrite bool
-	chReconcile  chan struct{}
-
 	client client.Client
 	logger *zap.SugaredLogger
-	m      sync.Mutex
 }
 
 // Returns a kubernetes status manager object. Parameters are:
@@ -62,193 +33,55 @@ type kubernetesManager struct {
 // - resync period that check for pending changes and writes to the ConfigMap if any.
 // - kubernetes client
 // - logger
-func NewKubernetesManager(ctx context.Context, name, namespace, cmkey, instance string, cacheExpiration, resyncPeriod time.Duration, kc client.Client, log *zap.SugaredLogger) status.Manager {
-	km := &kubernetesManager{
+func NewKubernetesBackend(name, namespace, cmkey, instance string, kc client.Client, log *zap.SugaredLogger) status.Backend {
+	km := &kubernetesBackend{
 		instance: instance,
 		key: client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,
 		},
 
-		cached: &status.Status{
-			Subscriptions: make(map[string]*status.SubscriptionStatus),
-		},
-		cacheExpiration: cacheExpiration,
-		resyncPeriod:    resyncPeriod,
-
-		pendingWrite: true,
-		chReconcile:  make(chan struct{}),
-
 		cmkey:  cmkey,
 		client: kc,
 
 		logger: log,
-		m:      sync.Mutex{},
 	}
-
-	go km.start(ctx)
 
 	return km
 }
 
-func (m *kubernetesManager) isCacheStale() bool {
-	return m.lastStatusWrite.Add(m.cacheExpiration).Before(time.Now())
-}
-
-func (m *kubernetesManager) start(ctx context.Context) {
-	ticker := time.NewTicker(m.resyncPeriod)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-m.chReconcile:
-			// fall out of select block
-		case <-ticker.C:
-			// fall out of select block
-		case <-ctx.Done():
-			return
-		}
-
-		// Skip if there are no pending writes and the
-		// cache is not stale
-		if !m.pendingWrite && !m.isCacheStale() {
-			continue
-		}
-
-		err := m.cachedToKubernetesConfigMap(ctx)
-		if err != nil {
-			m.logger.Errorw("could not read status configmap", zap.Error(err))
-		}
-	}
-}
-
-func (m *kubernetesManager) UpdateIngestStatus(is *status.IngestStatus) {
-	m.m.Lock()
-	defer m.m.Unlock()
-
-	if m.cached.Ingest.EqualStatus(is) {
-		// If status is equal do not enqueue an update.
-		return
-	}
-
-	m.cached.Ingest = *is
-
-	if m.cached.Ingest.EqualSoftStatus(is) {
-		// This update is not a priority, overwrite the ingest element and
-		// let a different status update (like the status cache expired)
-		// to writte it to the ConfigMap
-		return
-	}
-
-	// This update must be written asap. Mark the flag and send the signal
-	m.pendingWrite = true
-
-	m.maybeEnqueueReconcile()
-}
-
-func (m *kubernetesManager) EnsureSubscription(name string, ss *status.SubscriptionStatus) {
-	m.m.Lock()
-	defer m.m.Unlock()
-
-	s, ok := m.cached.Subscriptions[name]
-
-	// Fill not informed values with existing.
-	ss.Merge(s)
-
-	switch {
-	case ok && s.EqualStatus(ss):
-		// If status is equal do not enqueue an update.
-
-	case ok && s.EqualSoftStatus(ss):
-		m.cached.Subscriptions[name] = ss
-		// This update is not a priority, overwrite the ingest element and
-		// let a different status update (like the status cache expired)
-		// to writte it to the ConfigMap
-
-	default:
-		// Either a new subscription or an update that needs
-		// to be written asap
-
-		m.cached.Subscriptions[name] = ss
-
-		m.pendingWrite = true
-		m.maybeEnqueueReconcile()
-	}
-}
-func (m *kubernetesManager) EnsureNoSubscription(name string) {
-	m.m.Lock()
-	defer m.m.Unlock()
-
-	if _, ok := m.cached.Subscriptions[name]; ok {
-		delete(m.cached.Subscriptions, name)
-		m.pendingWrite = true
-		m.maybeEnqueueReconcile()
-	}
-}
-
-func (m *kubernetesManager) cachedToKubernetesConfigMap(ctx context.Context) error {
-	m.m.Lock()
-	defer m.m.Unlock()
-
-	cm, err := m.readConfigMap(ctx)
+func (b *kubernetesBackend) UpdateStatus(ctx context.Context, s *status.Status) error {
+	// Read current contents of the status at the ConfigMap.
+	cm := &corev1.ConfigMap{}
+	err := b.client.Get(ctx, b.key, cm)
 	if err != nil {
 		return fmt.Errorf("could not read status configmap: %w", err)
-	}
-
-	st := m.statusFromConfigMap(cm)
-	t := time.Now()
-	m.cached.LastUpdated = &t
-	st[m.instance] = *m.cached
-
-	b, err := json.Marshal(st)
-	if err != nil {
-		return fmt.Errorf("failed to marshal status: %w", err)
-	}
-
-	cm.Data[m.cmkey] = string(b)
-	if err = m.client.Update(ctx, cm, &client.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	m.lastStatusWrite = time.Now()
-	m.pendingWrite = false
-
-	return nil
-}
-
-func (m *kubernetesManager) readConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	cm := &corev1.ConfigMap{}
-	err := m.client.Get(ctx, m.key, cm)
-	if err != nil {
-		return nil, err
 	}
 
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
-	return cm, nil
-}
 
-func (m *kubernetesManager) statusFromConfigMap(cm *corev1.ConfigMap) map[string]status.Status {
+	// Parse ConfigMap key contents into a Status structure.
+	// If it does not exists or is not formatted an empty one will be used.
 	st := map[string]status.Status{}
-	data, ok := cm.Data[m.cmkey]
-	if !ok {
-		return st
+	data, ok := cm.Data[b.cmkey]
+	if ok {
+		if err := json.Unmarshal([]byte(data), &st); err != nil {
+			b.logger.Errorw("status ConfigMap contents could not be parsed. Status will be overwritten", zap.Error(err))
+		}
 	}
 
-	if err := json.Unmarshal([]byte(data), &st); err != nil {
-		m.logger.Errorw("status ConfigMap contents could not be parsed. Status will be overwritten", zap.Error(err))
+	st[b.instance] = *s
+	bst, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("failed to marshal status: %w", err)
 	}
 
-	return st
-}
-
-func (m *kubernetesManager) maybeEnqueueReconcile() {
-	select {
-	case m.chReconcile <- struct{}{}:
-	// Try to send but if busy skip
-
-	default:
-		m.logger.Debugw("Skipping status reconciliation due to full queue")
+	cm.Data[b.cmkey] = string(bst)
+	if err = b.client.Update(ctx, cm, &client.UpdateOptions{}); err != nil {
+		return err
 	}
+
+	return nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,5 +1,13 @@
 package status
 
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
 type SubscriptionStatusChoice string
 
 const (
@@ -24,8 +32,194 @@ const (
 	IngestStatusClosed IngestStatusChoice = "Closed"
 )
 
+type Backend interface {
+	UpdateStatus(ctx context.Context, s *Status) error
+}
+
 type Manager interface {
+	RegisterBackendStatusWriters(b Backend)
+	Start(ctx context.Context)
+
 	UpdateIngestStatus(is *IngestStatus)
 	EnsureSubscription(name string, ss *SubscriptionStatus)
 	EnsureNoSubscription(name string)
+}
+
+type manager struct {
+	// Cached structure for the status that avoids trying
+	// rewrites when there are no status changes.
+	//
+	// The cached structure will be considered stale after some
+	// configurable duration.
+	//
+	// lastStatusWrite checkpoints the last time the ConfigMap was written, and will be
+	// combined with cacheExpiration to calculate cache expiration
+	cached          *Status
+	cacheExpiration time.Duration
+	lastStatusWrite time.Time
+
+	// The status manager will run reconciling cycles according to the resyncPeriod duration.
+	// If the status cache has expired, the backend's update will be triggered.
+	//
+	// writeAsap is a flag set when a status change must be written at the next
+	// reconciliation, no matter if the cached status is stale or not.
+	//
+	// A reconcile cycle can be explicitly run using the chReconcile channel.
+	resyncPeriod time.Duration
+	writeAsap    bool
+	chReconcile  chan struct{}
+
+	// registered status reconciler channels
+	statusBackends []Backend
+
+	log *zap.SugaredLogger
+	m   sync.Mutex
+}
+
+func NewManager(cacheExpiration time.Duration, resyncPeriod time.Duration, log *zap.SugaredLogger) Manager {
+	return &manager{
+		cached:          &Status{Subscriptions: make(map[string]*SubscriptionStatus)},
+		cacheExpiration: cacheExpiration,
+
+		resyncPeriod: resyncPeriod,
+		writeAsap:    true,
+		chReconcile:  make(chan struct{}),
+
+		statusBackends: []Backend{},
+
+		log: log,
+		m:   sync.Mutex{},
+	}
+}
+
+func (m *manager) Start(ctx context.Context) {
+	ticker := time.NewTicker(m.resyncPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.chReconcile:
+			// fall out of select block
+		case <-ticker.C:
+			// fall out of select block
+		case <-ctx.Done():
+			return
+		}
+
+		// Skip if there are no pending writes and the
+		// cache is not stale
+		if !m.writeAsap && m.lastStatusWrite.Add(m.cacheExpiration).After(time.Now()) {
+			continue
+		}
+
+		m.updateStatus(ctx)
+	}
+}
+
+func (m *manager) updateStatus(ctx context.Context) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	// Touch last updated before sending to all backends.
+	m.cached.LastUpdated = time.Now()
+
+	// Iterate all registered status backends and call then.
+	failed := false
+	for i := range m.statusBackends {
+		if err := m.statusBackends[i].UpdateStatus(ctx, m.cached); err != nil {
+			if failed {
+				failed = true
+			}
+		}
+	}
+
+	// If all backends succeeded unset the writeAsap flag
+	// and set the last status timestamp
+	if !failed {
+		m.writeAsap = false
+		m.lastStatusWrite = time.Now()
+	}
+}
+
+func (m *manager) RegisterBackendStatusWriters(b Backend) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	m.statusBackends = append(m.statusBackends, b)
+}
+
+func (m *manager) UpdateIngestStatus(is *IngestStatus) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if m.cached.Ingest.EqualStatus(is) {
+		// If status is equal do not enqueue an update.
+		return
+	}
+
+	// If status differs from existing, update it at the structure.
+	m.cached.Ingest = *is
+
+	// This update is not a priority, overwrite the ingest element and
+	// let a different status update (like the status cache expired)
+	// to writte it to the ConfigMap
+	if m.cached.Ingest.EqualSoftStatus(is) {
+		return
+	}
+
+	// This update must be written asap. Mark the flag and send the signal
+	m.writeAsap = true
+
+	m.maybeEnqueueReconcile()
+}
+
+func (m *manager) EnsureSubscription(name string, ss *SubscriptionStatus) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	s, ok := m.cached.Subscriptions[name]
+
+	// Fill not informed values with existing.
+	ss.Merge(s)
+
+	switch {
+	case ok && s.EqualStatus(ss):
+		// If status is equal do not enqueue an update.
+
+	case ok && s.EqualSoftStatus(ss):
+		m.cached.Subscriptions[name] = ss
+		// This update is not a priority, overwrite the ingest element and
+		// let a different status update (like the status cache expired)
+		// to update the status.
+
+	default:
+		// Either a new subscription or an update that needs
+		// to be written asap
+
+		m.cached.Subscriptions[name] = ss
+
+		m.writeAsap = true
+		m.maybeEnqueueReconcile()
+	}
+}
+
+func (m *manager) EnsureNoSubscription(name string) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if _, ok := m.cached.Subscriptions[name]; ok {
+		delete(m.cached.Subscriptions, name)
+		m.writeAsap = true
+		m.maybeEnqueueReconcile()
+	}
+}
+
+func (m *manager) maybeEnqueueReconcile() {
+	select {
+	case m.chReconcile <- struct{}{}:
+	// Try to send but if busy skip
+
+	default:
+		m.log.Debugw("Skipping status reconciliation due to full queue")
+	}
 }

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -89,11 +89,7 @@ func (s *Status) EqualStatus(in *Status) bool {
 		}
 	}
 
-	if s.LastUpdated != in.LastUpdated {
-		return false
-	}
-
-	return true
+	return s.LastUpdated == in.LastUpdated
 }
 
 type IngestStatus struct {

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -12,7 +12,7 @@ type Status struct {
 	// More information on Duration format:
 	//  - https://www.iso.org/iso-8601-date-and-time-format.html
 	//  - https://en.wikipedia.org/wiki/ISO_8601
-	LastUpdated   *time.Time                     `json:"lastUpdated,omitempty"`
+	LastUpdated   time.Time                      `json:"lastUpdated,omitempty"`
 	Ingest        IngestStatus                   `json:"ingest,omitempty"`
 	Subscriptions map[string]*SubscriptionStatus `json:"subscriptions,omitempty"`
 }
@@ -89,9 +89,7 @@ func (s *Status) EqualStatus(in *Status) bool {
 		}
 	}
 
-	if s.LastUpdated == nil && in.LastUpdated != nil ||
-		s.LastUpdated != nil && in.LastUpdated == nil ||
-		(s.LastUpdated != nil && in.LastUpdated != nil && *s.LastUpdated != *in.LastUpdated) {
+	if s.LastUpdated != in.LastUpdated {
 		return false
 	}
 

--- a/test/e2e/test_runner.go
+++ b/test/e2e/test_runner.go
@@ -113,11 +113,13 @@ func (r *BrokerTestRunner) AddBroker(name string, port int, backend backend.Inte
 	observedLogger := zap.New(r.zapcore)
 
 	g := &pkgcmd.Globals{
-		Logger:           observedLogger.Sugar(),
-		Port:             port,
-		BrokerConfigPath: cfgfile.Name(),
-		Context:          r.mainCtx,
-		ConfigMethod:     pkgcmd.ConfigMethodFileWatcher,
+		Logger:            observedLogger.Sugar(),
+		Port:              port,
+		BrokerConfigPath:  cfgfile.Name(),
+		Context:           r.mainCtx,
+		ConfigMethod:      pkgcmd.ConfigMethodFileWatcher,
+		StatusCheckPeriod: time.Minute,
+		StatusForcePeriod: time.Minute,
 	}
 
 	i, err := broker.NewInstance(g, backend)


### PR DESCRIPTION
Status manager is now common to all status backends.

There is only one status backend for configmaps but there is room to add new backends if needed.