### PR TITLE
[Status]Remove stale status from ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Name | Environment | Default | Information
 broker-config-path        | BROKER_CONFIG_PATH              | /etc/triggermesh/broker.conf | Path to broker configuration file.
 observability-config-path | OBSERVABILITY_CONFIG_PATH       | | Path to observability configuration file.
 port                      | PORT                            | 8080 | HTTP Port to listen for CloudEvents.
-broker-name             | BROKER_NAME                   |`{hostname}` | Instance name. When running at Kubernetes should be set to RedisBroker name.
+broker-name             | BROKER_NAME                   |`{hostname}` | Instance name. When running at Kubernetes should be set to the pod name.
 kubernetes-namespace      | KUBERNETES_NAMESPACE            | | Namespace where the broker is running.
 kubernetes-broker-config-secret-name  | KUBERNETES_BROKER_CONFIG_SECRET_NAME | | Secret object name that contains the broker configuration.
 kubernetes-broker-config-secret-key   | KUBERNETES_BROKER_CONFIG_SECRET_KEY  | | Secret object key that contains the broker configuration.

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -83,6 +83,12 @@ func NewInstance(globals *cmd.Globals, b backend.Interface) (*Instance, error) {
 			globals.KubernetesStatusConfigmapKey,
 			// Broker instance
 			globals.BrokerName,
+			// When to delete other instances that might have been deleted
+			// from the ConfigMap status report.
+			// We will use 3 times the force period, which means the status will
+			// be removed for any instance that fails to update at least 2 times
+			// and up to 3 times their status at the ConfigMap
+			globals.StatusForcePeriod*3,
 			kc,
 			globals.Logger.Named("kubestatus"),
 		)


### PR DESCRIPTION
When working at Kubernetes some broker instances might be removed while the status structure still contains their data.

This PR let's other instances decide on when to remove stale information, up to 3 times the force resync period.